### PR TITLE
Rebrand from `ALFI-library` to `ALFI-lib`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ALFI-library/alfi-library.github.io
+module github.com/ALFI-lib/alfi-lib.github.io
 
 go 1.23.2
 

--- a/hugo.toml
+++ b/hugo.toml
@@ -1,4 +1,4 @@
-baseURL = 'https://alfi-library.github.io'
+baseURL = 'https://alfi-lib.github.io'
 
 defaultContentLanguageInSubdir = true
 disableDefaultLanguageRedirect = true
@@ -53,7 +53,7 @@ enableGitInfo = true
 	BookTheme = 'light'
 	BookToC = true
 	BookSection = 'docs'
-	BookRepo = 'https://github.com/ALFI-library/alfi-library.github.io'
+	BookRepo = 'https://github.com/ALFI-lib/alfi-lib.github.io'
 	BookEditPath = 'edit/main'
 	BookDateFormat = 'January 2, 2006'
 	BookSearch = true


### PR DESCRIPTION
### Types of changes
- Rebrand
- Configuration (project, go module)

### Description
Rebrand from `ALFI-library` to `ALFI-lib`.