### PR TITLE
Fixed `enableGitInfo` in `hugo.toml`

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -1,4 +1,5 @@
 baseURL = 'https://alfi-lib.github.io'
+enableGitInfo = true
 
 defaultContentLanguageInSubdir = true
 disableDefaultLanguageRedirect = true
@@ -45,9 +46,6 @@ disableDefaultLanguageRedirect = true
 [module]
 [[module.imports]]
 	path = 'github.com/pasabanov/hugo-book'
-
-disablePathToLower = false
-enableGitInfo = true
 
 [params]
 	BookTheme = 'light'


### PR DESCRIPTION
### Types of changes
- Configuration (Hugo)

Related: 8f09819ce4ee3c3bd0aa6b1e9a54302f9cbf49e6

### Description
In `hugo.toml`:
- Moved `enableGitInfo = true` to the global configuration scope (at the beginning of the file).
- Also removed `disablePathToLower = false`, since 1. it is the default value, and 2. it doesn’t work anyway.