### PR TITLE
Updated docs for "Not-a-knot" cubic spline

### DIFF
--- a/content/en/docs/splines/cubic/_index.md
+++ b/content/en/docs/splines/cubic/_index.md
@@ -183,23 +183,24 @@ Equations:
 - $h_2c_1 + (-h_2 - h_1)c_2 + h_1c_3 = 0$
 - $h_{n-1}c_{n-2} + (-h_{n-1} - h_{n-2})c_{n-1} + h_{n-2}c_n = 0$
 
-Matrix (almost triangular):
+Matrix:
 
 $$
 \begin{bmatrix}
-	h_2 & -h_2 - h_1 & h_1 & \dots & 0 & 0 & 0 \\
+	h_1 - h_2 & 2h_1 + h_2 & 0 & \dots & 0 & 0 & 0 \\
 	h_1 & 2h_1 + 2h_2 & h_2 & \dots & 0 & 0 & 0 \\
 	\vdots & \vdots & \vdots & \ddots & \vdots & \vdots & \vdots \\
 	0 & 0 & 0 & \dots & h_{n-2} & 2h_{n-2} + 2h_{n-1} & h_{n-1} \\
-	0 & 0 & 0 & \dots & h_{n-1} & -h_{n-1} - h_{n-2} & h_{n-2}
+	0 & 0 & 0 & \dots & 0 & h_{n-2} + 2h_{n-2} & -h_{n-2} + h_{n-1}
 \end{bmatrix}
 \begin{bmatrix}
 	c_1 \\ c_2 \\ \vdots \\ c_{n-1} \\ c_n
 \end{bmatrix}
 = \begin{bmatrix}
-	0 \\ R_1 \\ \vdots \\ R_{n-2} \\ 0
+	R_0 \\ R_1 \\ \vdots \\ R_{n-2} \\ R_{n-1}
 \end{bmatrix}
 $$
+where $R_0 = 3\frac{h_1}{h_1+h_2}\left(\frac{\delta_2}{h_2} - \frac{\delta_1}{h_1}\right)$, $R_k = 3\left(\frac{\delta_{k+1}}{h_{k+1}} - \frac{\delta_k}{h_k}\right)$, $R_{n-1} = 3\frac{h_{n-1}}{h_{n-1}+h_{n-2}}\left(\frac{\delta_{n-1}}{h_{n-1}} - \frac{\delta_{n-2}}{h_{n-2}}\right)$.
 
 [More about the "Not-a-knot" spline.](not-a-knot.md)
 

--- a/content/en/docs/splines/cubic/not-a-knot.md
+++ b/content/en/docs/splines/cubic/not-a-knot.md
@@ -15,32 +15,82 @@ From equation (5), we obtain:
 1. $\frac{c_2 - c_1}{3h_1} = \frac{c_3 - c_2}{3h_2} \Longrightarrow h_2c_2 - h_2c_1 = h_1c_3 - h_1c_2$
 2. $\frac{c_{n-1} - c_{n-2}}{3h_{n-2}} = \frac{c_n - c_{n-1}}{3h_{n-1}} \Longrightarrow h_{n-1}c_{n-1} - h_{n-1}c_{n-2} = h_{n-2}c_n - h_{n-2}c_{n-1}$
 
-From these, we obtain the two final equations:
-1. $h_2c_1 + (-h_2 - h_1)c_2 + h_1c_3 = 0$
-2. $h_{n-1}c_{n-2} + (-h_{n-1} - h_{n-2})c_{n-1} + h_{n-2}c_n = 0$
+, from which we obtain the two equations:
+$$
+\boxed{
+	h_2c_1 + (-h_2 - h_1)c_2 + h_1c_3 = 0
+}
+\tag{II.1}
+$$
+$$
+\boxed{
+	h_{n-1}c_{n-2} + (-h_{n-1} - h_{n-2})c_{n-1} + h_{n-2}c_n = 0
+}
+\tag{II.2}
+$$
 
-We place them into the matrix:
+From (7) for $k = 1$ we obtain:\
+$c_1(h_1) + c_2(2h_1 + 2h_2) + c_3(h_2) = 3\left(\frac{\delta_2}{h_2} - \frac{\delta_1}{h_1}\right)$
+
+We subtract this equation, multiplied by $\frac{h_1}{h_2}$, from (II.1) to eliminate the coefficient in front of $c_3$:\
+$c_1\left(h_2 - \frac{h_1^2}{h_2}\right) + c_2\left(-h_2 - h_1 - 2\frac{h_1^2}{h_2} - 2h_1\right) = -3\frac{h_1}{h_2}\left(\frac{\delta_2}{h_2} - \frac{\delta_1}{h_1}\right)$
+
+Factoring out the common multiplier from the coefficients:\
+$c_1\left(-\frac{h_1+h_2}{h_2}\right)(h_1-h_2) + c_2\left(-\frac{h_1+h_2}{h_2}\right)(2h_1+h_2) = \left(-\frac{h_1+h_2}{h_2}\right)\left(3\frac{h_1}{h_1+h_2}\left(\frac{\delta_2}{h_2} - \frac{\delta_1}{h_1}\right)\right)$
+
+And canceling out by $\left(-\frac{h_1+h_2}{h_2}\right)$:
+$$
+\boxed{
+	(h_1-h_2)c_1 + (2h_1+h_2)c_2 = 3\frac{h_1}{h_1+h_2}\left(\frac{\delta_2}{h_2} - \frac{\delta_1}{h_1}\right)
+}
+\tag{II.3}
+$$
+
+Similarly, we obtain the formula for the last row of the matrix:
+
+<details>
+<summary>Details</summary>
+
+From (7) for $k = n-2$ we obtain:\
+$c_{n-2}(h_{n-2}) + c_{n-1}(2h_{n-2} + 2h_{n-1}) + c_n(h_{n-1}) = 3\left(\frac{\delta_{n-1}}{h_{n-1}} - \frac{\delta_{n-2}}{h_{n-2}}\right)$
+
+We subtract this equation, multiplied by $\frac{h_{n-1}}{h_{n-2}}$, from (II.2) to eliminate the coefficient in front of $c_{n-2}$:\
+$c_{n-1}\left(-h_{n-1} - h_{n-2} - 2\frac{h_{n-1}^2}{h_{n-2}} - 2h_{n-1}\right) + c_n\left(h_{n-2} - \frac{h_{n-1}^2}{h_{n-2}}\right) = -3\frac{h_{n-1}}{h_{n-2}}\left(\frac{\delta_{n-1}}{h_{n-1}} - \frac{\delta_{n-2}}{h_{n-2}}\right)$
+
+Factoring out the common multiplier from the coefficients:\
+$c_{n-1}\left(-\frac{h_{n-1}+h_{n-2}}{h_{n-2}}\right)(2h_{n-1}+h_{n-2}) + c_n\left(-\frac{h_{n-1}+h_{n-2}}{h_{n-2}}\right)(h_{n-1}-h_{n-2}) = \left(-\frac{h_{n-1}+h_{n-2}}{h_{n-2}}\right)\left(3\frac{h_{n-1}}{h_{n-1}+h_{n-2}}\left(\frac{\delta_{n-1}}{h_{n-1}} - \frac{\delta_{n-2}}{h_{n-2}}\right)\right)$
+
+And canceling out by $\left(-\frac{h_{n-1}+h_{n-2}}{h_{n-2}}\right)$:\
+$c_{n-1}(2h_{n-1}+h_{n-2}) + c_n(h_{n-1}-h_{n-2}) = 3\frac{h_{n-1}}{h_{n-1}+h_{n-2}}\left(\frac{\delta_{n-1}}{h_{n-1}} - \frac{\delta_{n-2}}{h_{n-2}}\right)$
+</details>
+
+$$
+\boxed{
+	c_{n-1}(h_{n-2}+2h_{n-1}) + c_n(-h_{n-2}+h_{n-1}) = 3\frac{h_{n-1}}{h_{n-1}+h_{n-2}}\left(\frac{\delta_{n-1}}{h_{n-1}} - \frac{\delta_{n-2}}{h_{n-2}}\right)
+}
+\tag{II.4}
+$$
+
+Now, we place equations (II.3) and (II.4) into the matrix:
 
 $$
 \begin{bmatrix}
-	h_2 & -h_2 - h_1 & h_1 & 0 & \dots & 0 & 0 \\
+	h_1 - h_2 & 2h_1 + h_2 & 0 & 0 & \dots & 0 & 0 \\
 	h_1 & 2h_1 + 2h_2 & h_2 & 0 & \dots & 0 & 0 \\
 	0 & h_2 & 2h_2 + 2h_3 & h_3 & \dots & 0 & 0 \\
 	\vdots & \vdots & \vdots & \ddots & \ddots & \vdots & \vdots \\
 	0 & 0 & 0 & \dots & h_{n-2} & 2h_{n-2} + 2h_{n-1} & h_{n-1} \\
-	0 & 0 & 0 & \dots & h_{n-1} & -h_{n-1} - h_{n-2} & h_{n-2}
+	0 & 0 & 0 & \dots & 0 & h_{n-2} + 2h_{n-2} & -h_{n-2} + h_{n-1}
 \end{bmatrix}
 \begin{bmatrix}
 	c_1 \\ c_2 \\ c_3 \\ \vdots \\ c_{n-1} \\ c_n
 \end{bmatrix}
 = \begin{bmatrix}
-	0 \\ R_1 \\ R_2 \\ \vdots \\ R_{n-2} \\ 0
+	R_0 \\ R_1 \\ R_2 \\ \vdots \\ R_{n-2} \\ R_{n-1}
 \end{bmatrix}
 $$
-where $R_k = 3\left(\frac{\delta_{k+1}}{h_{k+1}} - \frac{\delta_k}{h_k}\right)$.
+where $R_0 = 3\frac{h_1}{h_1+h_2}\left(\frac{\delta_2}{h_2} - \frac{\delta_1}{h_1}\right)$, $R_k = 3\left(\frac{\delta_{k+1}}{h_{k+1}} - \frac{\delta_k}{h_k}\right)$, $R_{n-1} = 3\frac{h_{n-1}}{h_{n-1}+h_{n-2}}\left(\frac{\delta_{n-1}}{h_{n-1}} - \frac{\delta_{n-2}}{h_{n-2}}\right)$.
 
-In this case, the matrix is not triangular but can be quite easily converted into a triangular form.
-
-After converting it into a triangular form, the matrix can be solved using the [tridiagonal matrix algorithm](https://en.wikipedia.org/wiki/Tridiagonal_matrix_algorithm).
+Now the matrix can be solved using the [tridiagonal matrix algorithm](https://en.wikipedia.org/wiki/Tridiagonal_matrix_algorithm).
 
 After finding the coefficients $c_k$, the other coefficients $b_k$ and $d_k$ can be calculated using formulas (6) and (5) respectively.

--- a/content/ru/docs/splines/cubic/_index.md
+++ b/content/ru/docs/splines/cubic/_index.md
@@ -182,23 +182,24 @@ $$
 - $h_2c_1 + (-h_2 - h_1)c_2 + h_1c_3 = 0$
 - $h_{n-1}c_{n-2} + (-h_{n-1} - h_{n-2})c_{n-1} + h_{n-2}c_n = 0$
 
-Матрица (почти треугольная):
+Матрица:
 
 $$
 \begin{bmatrix}
-	h_2 & -h_2 - h_1 & h_1 & \dots & 0 & 0 & 0 \\
+	h_1 - h_2 & 2h_1 + h_2 & 0 & \dots & 0 & 0 & 0 \\
 	h_1 & 2h_1 + 2h_2 & h_2 & \dots & 0 & 0 & 0 \\
 	\vdots & \vdots & \vdots & \ddots & \vdots & \vdots & \vdots \\
 	0 & 0 & 0 & \dots & h_{n-2} & 2h_{n-2} + 2h_{n-1} & h_{n-1} \\
-	0 & 0 & 0 & \dots & h_{n-1} & -h_{n-1} - h_{n-2} & h_{n-2}
+	0 & 0 & 0 & \dots & 0 & h_{n-2} + 2h_{n-2} & -h_{n-2} + h_{n-1}
 \end{bmatrix}
 \begin{bmatrix}
 	c_1 \\ c_2 \\ \vdots \\ c_{n-1} \\ c_n
 \end{bmatrix}
 = \begin{bmatrix}
-	0 \\ R_1 \\ \vdots \\ R_{n-2} \\ 0
+	R_0 \\ R_1 \\ \vdots \\ R_{n-2} \\ R_{n-1}
 \end{bmatrix}
 $$
+, где $R_0 = 3\frac{h_1}{h_1+h_2}\left(\frac{\delta_2}{h_2} - \frac{\delta_1}{h_1}\right)$, $R_k = 3\left(\frac{\delta_{k+1}}{h_{k+1}} - \frac{\delta_k}{h_k}\right)$, $R_{n-1} = 3\frac{h_{n-1}}{h_{n-1}+h_{n-2}}\left(\frac{\delta_{n-1}}{h_{n-1}} - \frac{\delta_{n-2}}{h_{n-2}}\right)$.
 
 [Подробнее про "Not-a-knot" сплайн.](not-a-knot.md)
 

--- a/content/ru/docs/splines/cubic/not-a-knot.md
+++ b/content/ru/docs/splines/cubic/not-a-knot.md
@@ -15,32 +15,82 @@ weight = 2
 1. $\frac{c_2 - c_1}{3h_1} = \frac{c_3 - c_2}{3h_2} \Longrightarrow h_2c_2 - h_2c_1 = h_1c_3 - h_1c_2$
 2. $\frac{c_{n-1} - c_{n-2}}{3h_{n-2}} = \frac{c_n - c_{n-1}}{3h_{n-1}} \Longrightarrow h_{n-1}c_{n-1} - h_{n-1}c_{n-2} = h_{n-2}c_n - h_{n-2}c_{n-1}$
 
-, из которых получаем два итоговых уравнения:
-1. $h_2c_1 + (-h_2 - h_1)c_2 + h_1c_3 = 0$
-2. $h_{n-1}c_{n-2} + (-h_{n-1} - h_{n-2})c_{n-1} + h_{n-2}c_n = 0$
+, из которых получаем два уравнения:
+$$
+\boxed{
+	h_2c_1 + (-h_2 - h_1)c_2 + h_1c_3 = 0
+}
+\tag{II.1}
+$$
+$$
+\boxed{
+	h_{n-1}c_{n-2} + (-h_{n-1} - h_{n-2})c_{n-1} + h_{n-2}c_n = 0
+}
+\tag{II.2}
+$$
 
-Заносим их в матрицу:
+Из (7) для $k = 1$ получаем:\
+$c_1(h_1) + c_2(2h_1 + 2h_2) + c_3(h_2) = 3\left(\frac{\delta_2}{h_2} - \frac{\delta_1}{h_1}\right)$
+
+Вычитаем это уравнение, умноженное на $\frac{h_1}{h_2}$, из (II.1), чтобы занулить коэффициент перед $c_3$:\
+$c_1\left(h_2 - \frac{h_1^2}{h_2}\right) + c_2\left(-h_2 - h_1 - 2\frac{h_1^2}{h_2} - 2h_1\right) = -3\frac{h_1}{h_2}\left(\frac{\delta_2}{h_2} - \frac{\delta_1}{h_1}\right)$
+
+Выносим общий множитель из коэффициентов:\
+$c_1\left(-\frac{h_1+h_2}{h_2}\right)(h_1-h_2) + c_2\left(-\frac{h_1+h_2}{h_2}\right)(2h_1+h_2) = \left(-\frac{h_1+h_2}{h_2}\right)\left(3\frac{h_1}{h_1+h_2}\left(\frac{\delta_2}{h_2} - \frac{\delta_1}{h_1}\right)\right)$
+
+И сокращаем на $\left(-\frac{h_1+h_2}{h_2}\right)$:
+$$
+\boxed{
+	(h_1-h_2)c_1 + (2h_1+h_2)c_2 = 3\frac{h_1}{h_1+h_2}\left(\frac{\delta_2}{h_2} - \frac{\delta_1}{h_1}\right)
+}
+\tag{II.3}
+$$
+
+Аналогично получаем формулу для последней строки матрицы:
+
+<details>
+<summary>Подробнее</summary>
+
+Из (7) для $k = n-2$ получаем:\
+$c_{n-2}(h_{n-2}) + c_{n-1}(2h_{n-2} + 2h_{n-1}) + c_n(h_{n-1}) = 3\left(\frac{\delta_{n-1}}{h_{n-1}} - \frac{\delta_{n-2}}{h_{n-2}}\right)$
+
+Вычитаем это уравнение, умноженное на $\frac{h_{n-1}}{h_{n-2}}$, из (II.2), чтобы занулить коэффициент перед $c_{n-2}$:\
+$c_{n-1}\left(-h_{n-1} - h_{n-2} - 2\frac{h_{n-1}^2}{h_{n-2}} - 2h_{n-1}\right) + c_n\left(h_{n-2} - \frac{h_{n-1}^2}{h_{n-2}}\right) = -3\frac{h_{n-1}}{h_{n-2}}\left(\frac{\delta_{n-1}}{h_{n-1}} - \frac{\delta_{n-2}}{h_{n-2}}\right)$
+
+Выносим общий множитель из коэффициентов:\
+$c_{n-1}\left(-\frac{h_{n-1}+h_{n-2}}{h_{n-2}}\right)(2h_{n-1}+h_{n-2}) + c_n\left(-\frac{h_{n-1}+h_{n-2}}{h_{n-2}}\right)(h_{n-1}-h_{n-2}) = \left(-\frac{h_{n-1}+h_{n-2}}{h_{n-2}}\right)\left(3\frac{h_{n-1}}{h_{n-1}+h_{n-2}}\left(\frac{\delta_{n-1}}{h_{n-1}} - \frac{\delta_{n-2}}{h_{n-2}}\right)\right)$
+
+И сокращаем на $\left(-\frac{h_{n-1}+h_{n-2}}{h_{n-2}}\right)$:\
+$c_{n-1}(2h_{n-1}+h_{n-2}) + c_n(h_{n-1}-h_{n-2}) = 3\frac{h_{n-1}}{h_{n-1}+h_{n-2}}\left(\frac{\delta_{n-1}}{h_{n-1}} - \frac{\delta_{n-2}}{h_{n-2}}\right)$
+</details>
+
+$$
+\boxed{
+	c_{n-1}(h_{n-2}+2h_{n-1}) + c_n(-h_{n-2}+h_{n-1}) = 3\frac{h_{n-1}}{h_{n-1}+h_{n-2}}\left(\frac{\delta_{n-1}}{h_{n-1}} - \frac{\delta_{n-2}}{h_{n-2}}\right)
+}
+\tag{II.4}
+$$
+
+Заносим уравнения (II.3) и (II.4) в матрицу:
 
 $$
 \begin{bmatrix}
-	h_2 & -h_2 - h_1 & h_1 & 0 & \dots & 0 & 0 \\
+	h_1 - h_2 & 2h_1 + h_2 & 0 & 0 & \dots & 0 & 0 \\
 	h_1 & 2h_1 + 2h_2 & h_2 & 0 & \dots & 0 & 0 \\
 	0 & h_2 & 2h_2 + 2h_3 & h_3 & \dots & 0 & 0 \\
 	\vdots & \vdots & \vdots & \ddots & \ddots & \vdots & \vdots \\
 	0 & 0 & 0 & \dots & h_{n-2} & 2h_{n-2} + 2h_{n-1} & h_{n-1} \\
-	0 & 0 & 0 & \dots & h_{n-1} & -h_{n-1} - h_{n-2} & h_{n-2}
+	0 & 0 & 0 & \dots & 0 & h_{n-2} + 2h_{n-2} & -h_{n-2} + h_{n-1}
 \end{bmatrix}
 \begin{bmatrix}
 	c_1 \\ c_2 \\ c_3 \\ \vdots \\ c_{n-1} \\ c_n
 \end{bmatrix}
 = \begin{bmatrix}
-	0 \\ R_1 \\ R_2 \\ \vdots \\ R_{n-2} \\ 0
+	R_0 \\ R_1 \\ R_2 \\ \vdots \\ R_{n-2} \\ R_{n-1}
 \end{bmatrix}
 $$
-, где $R_k = 3\left(\frac{\delta_{k+1}}{h_{k+1}} - \frac{\delta_k}{h_k}\right)$.
+, где $R_0 = 3\frac{h_1}{h_1+h_2}\left(\frac{\delta_2}{h_2} - \frac{\delta_1}{h_1}\right)$, $R_k = 3\left(\frac{\delta_{k+1}}{h_{k+1}} - \frac{\delta_k}{h_k}\right)$, $R_{n-1} = 3\frac{h_{n-1}}{h_{n-1}+h_{n-2}}\left(\frac{\delta_{n-1}}{h_{n-1}} - \frac{\delta_{n-2}}{h_{n-2}}\right)$.
 
-В данном случае матрица не треугольная, но может быть довольно просто приведена к треугольному виду.
-
-После приведения к треугольному виду матрицу можно решить с помощью [метода прогонки](https://ru.wikipedia.org/wiki/Метод_прогонки).
+Теперь матрицу можно решить с помощью [метода прогонки](https://ru.wikipedia.org/wiki/Метод_прогонки).
 
 После нахождения коэффициентов $c_k$ остальные коэффициенты $b_k$ и $d_k$ можно вычислить по формулам (6) и (5) соответственно.


### PR DESCRIPTION
### Types of changes
- Feature
- Refactoring, reformatting, cleanup

Related: #3 #5 

### Description
The tridiagonal matrix is now presented with the coefficients $a_{1,3}$ and $a_{n,n-2}$ zeroed. This differs from the previous "almost" tridiagonal matrix, where these coefficients were not zeroed.