### PR TITLE
Fixed Git commit info for GitHub workflows

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          submodules: recursive
+          fetch-depth: 0
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v5


### PR DESCRIPTION
### Types of changes
- Bug fix
- Configuration (CI/CD)

Related: 

### Description
Previously, the Git information that Hugo added to the pages (date and commit link) because of the `enableGitInfo = true` setting in `hugo.toml` was incorrect: it displayed the date of the latest commit and the link to the latest commit.
This was caused by the fact that by default, `actions/checkout` created a "shallow" copy of the repository, cloning only the latest commit.

Now, `actions/checkout` will clone all commits due to the `fetch-depth: 0` setting.

Also, the `submodules: recursive` setting has been removed as it was unnecessary.